### PR TITLE
feat: Add a User Agent to cc-downloader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,11 @@ reqwest-retry = "0.7.0"
 tokio = { version = "1.42.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["compat"] }
 url = "2.5.4"
+
+[dev-dependencies]
+serde = { version = "1.0.217", features = ["derive"] }
+reqwest = { version = "0.12.9", default-features = false, features = [
+    "stream",
+    "rustls-tls",
+    "json",
+] }


### PR DESCRIPTION
This commit adds a User Agent to cc-downloader so that its use can better be tracked. 
It adds a refactor to the way the client is built so that the code is reused by both the download-paths and download functions. 
It also adds 2 tests to check that the user agent is properly set.
