### PR TITLE
CC-NEWS support and validation for crawl reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
 name = "cc-downloader"
 version = "0.5.2"
-edition = "2021"
+edition = "2024"
 authors = ["Pedro Ortiz Suarez <pedro@commoncrawl.org>"]
 description = "A polite and user-friendly downloader for Common Crawl data."
 license = "MIT OR Apache-2.0"
-rust-version = "1.83"
+rust-version = "1.85"
 readme = "README.md"
 homepage = "https://commoncrawl.org"
 repository = "https://github.com/commoncrawl/cc-downloader"
 documentation = "https://docs.rs/cc-downloader"
 
 [dependencies]
-clap = { version = "4.5.29", features = ["derive"] }
-flate2 = "1.0.35"
+clap = { version = "4.5.31", features = ["derive"] }
+flate2 = "1.1.0"
 futures = "0.3.31"
 indicatif = "0.17.11"
 reqwest = { version = "0.12.12", default-features = false, features = [
     "stream",
     "rustls-tls",
 ] }
-reqwest-middleware = "0.4.0"
+reqwest-middleware = "0.4.1"
 reqwest-retry = "0.7.0"
 tokio = { version = "1.43.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["compat"] }
 url = "2.5.4"
 
 [dev-dependencies]
-serde = { version = "1.0.217", features = ["derive"] }
+serde = { version = "1.0.218", features = ["derive"] }
 reqwest = { version = "0.12.12", default-features = false, features = [
     "stream",
     "rustls-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4.5.31", features = ["derive"] }
 flate2 = "1.1.0"
 futures = "0.3.31"
 indicatif = "0.17.11"
+regex = "1.11.1"
 reqwest = { version = "0.12.12", default-features = false, features = [
     "stream",
     "rustls-tls",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,8 +98,8 @@ fn crawl_name_format(crawl: &str) -> Result<String, String> {
     let crawl_ref = crawl.to_uppercase();
 
     if !(main_re.is_match(&crawl_ref) || news_re.is_match(&crawl_ref)) {
-        return Err("Please use the CC-MAIN-YYYY-WW or the CC-NEWS-YYYY-MM format.".to_string());
+        Err("Please use the CC-MAIN-YYYY-WW or the CC-NEWS-YYYY-MM format.".to_string())
     } else {
-        return Ok(crawl_ref);
+        Ok(crawl_ref)
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,9 +95,11 @@ fn crawl_name_format(crawl: &str) -> Result<String, String> {
     let main_re = Regex::new(r"^(CC\-MAIN)\-([0-9]{4})\-([0-9]{2})$").unwrap();
     let news_re = Regex::new(r"^(CC\-NEWS)\-([0-9]{4})\-([0-9]{2})$").unwrap();
 
-    if !(main_re.is_match(crawl) || news_re.is_match(crawl)) {
-        return Err("Please use the CC-MAIN-YYYY-WW or the CC-NEWS-YYYY-MM format, make sure your input is propely capitalized".to_string());
+    let crawl_ref = crawl.to_uppercase();
+
+    if !(main_re.is_match(&crawl_ref) || news_re.is_match(&crawl_ref)) {
+        return Err("Please use the CC-MAIN-YYYY-WW or the CC-NEWS-YYYY-MM format.".to_string());
     } else {
-        return Ok(crawl.to_owned());
+        return Ok(crawl_ref);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
+use regex::Regex;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -13,8 +14,8 @@ pub struct Cli {
 pub enum Commands {
     /// Download paths for a given crawl
     DownloadPaths {
-        /// Crawl reference, e.g. CC-MAIN-2021-04
-        #[arg(value_name = "CRAWL")]
+        /// Crawl reference, e.g. CC-MAIN-2021-04 or CC-NEWS-2025-01
+        #[arg(value_name = "CRAWL", value_parser = crawl_name_format)]
         snapshot: String,
 
         /// Data type
@@ -87,5 +88,18 @@ impl DataType {
             DataType::CcIndex => "cc-index",
             DataType::CcIndexTable => "cc-index-table",
         }
+    }
+}
+
+//https://data.commoncrawl.org/crawl-data/CC-NEWS/2025/01/warc.paths.gz
+
+fn crawl_name_format(crawl: &str) -> Result<String, String> {
+    let main_re = Regex::new(r"^(CC\-MAIN)\-([0-9]{4})\-([0-9]{2})$").unwrap();
+    let news_re = Regex::new(r"^(CC\-NEWS)\-([0-9]{4})\-([0-9]{2})$").unwrap();
+
+    if !(main_re.is_match(crawl) || news_re.is_match(crawl)) {
+        return Err("Please use the CC-MAIN-YYYY-WW or the CC-NEWS-YYYY-MM format, make sure your input is propely capitalized".to_string());
+    } else {
+        return Ok(crawl.to_owned());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,8 +91,6 @@ impl DataType {
     }
 }
 
-//https://data.commoncrawl.org/crawl-data/CC-NEWS/2025/01/warc.paths.gz
-
 fn crawl_name_format(crawl: &str) -> Result<String, String> {
     let main_re = Regex::new(r"^(CC\-MAIN)\-([0-9]{4})\-([0-9]{2})$").unwrap();
     let news_re = Regex::new(r"^(CC\-NEWS)\-([0-9]{4})\-([0-9]{2})$").unwrap();


### PR DESCRIPTION
## Description

This PR introduces support for CC-NEWS and adds validations for the crawl or snapshot references. This PR also updates some libraries and bumps the rust edition to 2024 and the latest 1.85 version.

## Breaking Changes

No Breaking changes

## Notes & open questions

The error messages can still be fine-tuned a little bit.
